### PR TITLE
chore: changed to not use plugin if `import.meta.resolve` is undefined

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
   },
   "eslint.nodePath": ".yarn/sdks",
   "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs",
-  "prettier.configPath": "prettier.config.mjs",
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/apps/www/prettier.config.mjs
+++ b/apps/www/prettier.config.mjs
@@ -1,9 +1,12 @@
 /** @type {import('prettier').Config} */
 const prettierConfig = {
-  plugins: [
-    import.meta.resolve('prettier-plugin-organize-imports'),
-    import.meta.resolve('prettier-plugin-tailwindcss'),
-  ],
+  plugins:
+    typeof import.meta.resolve === 'function'
+      ? [
+          import.meta.resolve('prettier-plugin-organize-imports'),
+          import.meta.resolve('prettier-plugin-tailwindcss'),
+        ]
+      : [],
   singleQuote: true,
 };
 

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,7 +1,10 @@
 /** @type {import('prettier').Config} */
-const lintStagedConfig = {
-  plugins: [import.meta.resolve('prettier-plugin-organize-imports')],
+const prettierConfig = {
+  plugins:
+    typeof import.meta.resolve === 'function'
+      ? [import.meta.resolve('prettier-plugin-organize-imports')]
+      : [],
   singleQuote: true,
 };
 
-export default lintStagedConfig;
+export default prettierConfig;


### PR DESCRIPTION
changed to not use plugin because formatting with `prettier-vscode` causes `import.meta.resolve` to be undefined and formatting fails